### PR TITLE
feat(packages/passport): separate the error handler for refresh token rotation

### DIFF
--- a/packages/passport-react/CHANGELOG.md
+++ b/packages/passport-react/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.3](https://github.com/maxverse-dev/maxverse-web-sdk/compare/@maxverse/passport-react@0.3.2...@maxverse/passport-react@0.3.3) (2023-10-11)
+
+**Note:** Version bump only for package @maxverse/passport-react
+
+
+
+
+
 ## [0.3.2](https://github.com/maxverse-dev/maxverse-web-sdk/compare/@maxverse/passport-react@0.3.1...@maxverse/passport-react@0.3.2) (2023-10-11)
 
 

--- a/packages/passport-react/package.json
+++ b/packages/passport-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxverse/passport-react",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "keywords": [
     "login",
     "Authorization Code Grant Flow",
@@ -39,7 +39,7 @@
     "@babel/preset-env": "^7.16.4",
     "@babel/preset-typescript": "^7.18.6",
     "@babel/runtime": "^7.16.3",
-    "@maxverse/passport-web-sdk": "^0.4.1",
+    "@maxverse/passport-web-sdk": "^0.4.2",
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",
     "@types/jest": "^29.5.1",

--- a/packages/passport/CHANGELOG.md
+++ b/packages/passport/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.4.2](https://github.com/maxverse-dev/maxverse-web-sdk/compare/@maxverse/passport-web-sdk@0.4.1...@maxverse/passport-web-sdk@0.4.2) (2023-10-11)
+
+
+### Features
+
+* **packages/passport:** change passport domain ([8646507](https://github.com/maxverse-dev/maxverse-web-sdk/commit/8646507df24b56ce26b55c67f1136382f7a327f1))
+* **packages/passport:** seperate error handler of refresh token rotation ([01fe2f9](https://github.com/maxverse-dev/maxverse-web-sdk/commit/01fe2f970b36a5f2fb879ee6856c61ae8aa1eb62))
+
+
+
+
+
 ## [0.4.1](https://github.com/maxverse-dev/maxverse-web-sdk/compare/@maxverse/passport-web-sdk@0.4.0...@maxverse/passport-web-sdk@0.4.1) (2023-10-10)
 
 

--- a/packages/passport/package.json
+++ b/packages/passport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxverse/passport-web-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "keywords": [
     "login",
     "Authorization Code Grant Flow",

--- a/packages/passport/src/api/index.ts
+++ b/packages/passport/src/api/index.ts
@@ -14,7 +14,7 @@ export class HttpClient {
 
   async #fetchJSON(endpoint: string, options: RequestInit = {}) {
     try {
-      const res = await fetch(`${this.#baseUrl}/api/passport/${endpoint}`, {
+      const res = await fetch(`${this.#baseUrl}/passport/${endpoint}`, {
         ...options,
         headers: this.#headers,
       });

--- a/packages/passport/src/helpers/common/index.ts
+++ b/packages/passport/src/helpers/common/index.ts
@@ -81,7 +81,7 @@ export const parseAuthenticationResult = (queryString: string): AuthenticationRe
 };
 
 export const composeUrl = (domain: string, req: string, params: string) => {
-  return `${domain}/api/passport/${req}?${params}`;
+  return `${domain}/passport/${req}?${params}`;
 };
 
 export const nowTime = () => new Date().getTime();

--- a/packages/passport/src/index.ts
+++ b/packages/passport/src/index.ts
@@ -1,2 +1,3 @@
 export * from './app';
+export * from './constants/error';
 export * from './types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2173,7 +2173,7 @@ __metadata:
     "@babel/preset-env": ^7.16.4
     "@babel/preset-typescript": ^7.18.6
     "@babel/runtime": ^7.16.3
-    "@maxverse/passport-web-sdk": ^0.4.1
+    "@maxverse/passport-web-sdk": ^0.4.2
     "@types/babel__core": ^7
     "@types/babel__preset-env": ^7
     "@types/jest": ^29.5.1
@@ -2194,7 +2194,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@maxverse/passport-web-sdk@^0.4.1, @maxverse/passport-web-sdk@workspace:packages/passport":
+"@maxverse/passport-web-sdk@^0.4.2, @maxverse/passport-web-sdk@workspace:packages/passport":
   version: 0.0.0-use.local
   resolution: "@maxverse/passport-web-sdk@workspace:packages/passport"
   dependencies:


### PR DESCRIPTION
### **Issue close**

#114 

### **Overview**

- change passport endpoint
  - `api/passport` => `/passsport`
